### PR TITLE
Sort profiles by cost explicitly

### DIFF
--- a/dozer/profile.py
+++ b/dozer/profile.py
@@ -120,7 +120,7 @@ class Profiler(object):
                     max_cost = max(max_cost, total_cost)
                     profiles.append((modified, environ, total_cost, profile_file[:-4]))
 
-        profiles.sort(reverse=True)
+        profiles.sort(reverse=True, key=lambda p: p[2])
         errors.sort(reverse=True)
         res = Response()
         if profiles:


### PR DESCRIPTION
Otherwise it just raises this: `TypeError: '<' not supported between instances of 'dict' and 'dict'`