### PR TITLE
Fix tick() for objects with duplicate (type.__module__, type.__name__)

### DIFF
--- a/dozer/leak.py
+++ b/dozer/leak.py
@@ -1,4 +1,5 @@
 import cgi
+import collections
 import gc
 import os
 import re
@@ -159,16 +160,13 @@ class Dozer(object):
     def tick(self):
         gc.collect()
 
-        typecounts = {}
+        typenamecounts = collections.defaultdict(int)
         for obj in gc.get_objects():
             objtype = type(obj)
-            if objtype in typecounts:
-                typecounts[objtype] += 1
-            else:
-                typecounts[objtype] = 1
-
-        for objtype, count in typecounts.items():
             typename = "%s.%s" % (objtype.__module__, objtype.__name__)
+            typenamecounts[typename] += 1
+
+        for typename, count in typenamecounts.items():
             if typename not in self.history:
                 self.history[typename] = [0] * self.samples
             self.history[typename].append(count)


### PR DESCRIPTION
I can see that for  `marshmallow.schema.ParamSchema`, which is a group of auto-generated classes, and a couple of others, the charts look like: 

![image](https://user-images.githubusercontent.com/5774272/78580643-fdcd2780-7832-11ea-89b5-d38ab2ca0ed9.png)

This happens because `(type.__module__, type.__name__)` may be not unique. This PR aggregates counts per `(type.__module__, type.__name__)` which solves the issue.