### PR TITLE
Fix tracing of objects that raise on property or descriptor access

### DIFF
--- a/dozer/leak.py
+++ b/dozer/leak.py
@@ -290,7 +290,10 @@ class Dozer(object):
                     # Attributes
                     rows.append('<div class="obj"><h3>Attributes</h3>')
                     for k in dir(obj):
-                        v = getattr(obj, k, AttributeError)
+                        try:
+                            v = getattr(obj, k, AttributeError)
+                        except Exception as ex:
+                            v = ex
                         if type(v) not in method_types:
                             rows.append('<p class="attr"><b>%s:</b> %s</p>' %
                                         (k, get_repr(v)))

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
     pytest {posargs}
 
 [testenv:coverage]
-basepython = python2
+basepython = python3
 deps =
     coverage
 commands =


### PR DESCRIPTION
1. Fix tracing of objects that raise on property or descriptor access.
2. 100% coverage of `test_leak`. 