### PR TITLE
Python 3.13 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
 
     steps:
       - name: Git clone

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,11 @@ Dozer Changelog
 0.9 (unreleased)
 ----------------
 
-- Add support for Python 3.10, 3.10, and 3.12.
+- Add support for Python 3.10, 3.11, 3.12, and 3.13.
 - Drop support for Python 2.7, 3.6 and 3.7.
+- Stop using the cgi module (which wasn't really being used).
+- Possibly fix a bug where unbound methods were not being filtered out properly
+  in memory leak reports.
 
 
 0.8 (November 13, 2020)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ environment:
     - PYTHON: "C:\\Python310-x64"
     - PYTHON: "C:\\Python311-x64"
     - PYTHON: "C:\\Python312-x64"
+    - PYTHON: "C:\\Python313-x64"
 
 init:
   - "echo %PYTHON%"

--- a/dozer/leak.py
+++ b/dozer/leak.py
@@ -1,4 +1,3 @@
-import cgi
 import collections
 import gc
 import os
@@ -7,6 +6,7 @@ import sys
 import threading
 import time
 import traceback
+import types
 import warnings
 from io import BytesIO
 from types import FrameType, ModuleType
@@ -61,11 +61,14 @@ class _(object):
 
 dictproxy = type(_.__dict__)
 
-method_types = [type(tuple.__le__),                 # 'wrapper_descriptor'
-                type([1].__le__),                   # 'method-wrapper'
-                type(sys.getsizeof),                # 'builtin_function_or_method'
-                type(cgi.FieldStorage.getfirst),    # 'instancemethod'
-                ]
+method_types = [
+    types.BuiltinFunctionType,      # 'builtin_function_or_method'
+    types.BuiltinMethodType,        # 'builtin_function_or_method'
+    types.MethodWrapperType,        # 'method-wrapper'
+    types.WrapperDescriptorType,    # 'wrapper_descriptor'
+    types.MethodType,               # 'method' aka bound method
+    types.FunctionType,             # 'function' and also unbound method
+]
 
 
 sort_keys = {

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: WSGI",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py39, py310, py311, py312
+envlist = py38, py39, py310, py311, py312, py313
 minversion = 2.4
 
 [testenv]


### PR DESCRIPTION
- Stop importing the `cgi` module (it was only used to get the type of an
  unbound method)
- Use the types module instead of calling type() on random methods
- Make sure `method_types` contains unbound methods (which are the same as
  functions on Python 3), which probably fixes a long-standing bug since the
  Python 3 port.

Unfortunately this is not enough to support Python 3.13, as we depend on webob,
and webob doesn't support 3.13 yet.  See
https://github.com/Pylons/webob/issues/437.
